### PR TITLE
fix(devcontainer): symlink plugin skills into workspace for AI discoverability

### DIFF
--- a/.devcontainer/scripts/lib.sh
+++ b/.devcontainer/scripts/lib.sh
@@ -465,6 +465,20 @@ install_claude_plugin() {
     local plugins_json="/root/.claude/plugins/installed_plugins.json"
     local cache_base="/root/.claude/plugins/cache/${marketplace}/${plugin_name}"
 
+    # Ensure workspace symlink so AI file search can find plugin skills.
+    # The plugin runtime injects skills via JS hook, but Claude (the AI model)
+    # also needs to read SKILL.md files during conversations — and it searches
+    # the workspace tree, not ~/.claude/plugins/cache/.
+    _link_plugin_skills() {
+        local target_skills="$1/skills"
+        local link_path="${WORKSPACE_ROOT}/.agents/skills/${plugin_name}"
+        if [ -d "$target_skills" ]; then
+            mkdir -p "$(dirname "$link_path")"
+            ln -sfn "$target_skills" "$link_path"
+            logm claude "${plugin_name}: linked skills → ${link_path}"
+        fi
+    }
+
     # Check if already installed by looking at installed_plugins.json
     if [ -f "$plugins_json" ] && python3 -c "
 import json, sys
@@ -475,7 +489,15 @@ if entries and entries[0].get('installPath'):
     sys.exit(0 if os.path.isdir(entries[0]['installPath']) else 1)
 sys.exit(1)
 " 2>/dev/null; then
-        logm claude "superpowers: already installed"
+        # Plugin exists — still ensure the workspace symlink is current
+        local existing_path
+        existing_path=$(python3 -c "
+import json
+d = json.load(open('$plugins_json'))
+print(d['plugins']['$plugin_key'][0]['installPath'])
+" 2>/dev/null)
+        [ -n "$existing_path" ] && _link_plugin_skills "$existing_path"
+        logm claude "${plugin_name}: already installed"
         return 0
     fi
 
@@ -522,6 +544,7 @@ d['plugins']['$plugin_key'] = [{
 }]
 json.dump(d, open(path, 'w'), indent=2)
 "
+    _link_plugin_skills "$install_path"
     logm claude "superpowers: installed v${version}"
 }
 

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ node_modules/
 .fastembed_cache/
 .worktrees/
 .superpowers/
+
+# Plugin skill symlinks (created by install_claude_plugin, env-specific)
+.agents/skills/superpowers


### PR DESCRIPTION
## Summary
- `install_claude_plugin` now creates `.agents/skills/<plugin>` → plugin cache symlink so Claude can find SKILL.md files via workspace search
- Symlink created on both fresh-install and already-installed paths (idempotent via `ln -sfn`)
- Gitignored since the symlink target is environment-specific (`~/.claude/plugins/cache/`)

## Context
The superpowers plugin runtime injects skills via JS hook, but Claude (the AI model) also needs to **read** SKILL.md files during conversations — and it only searches the workspace tree, not `~/.claude/plugins/cache/`. This caused skills to be "not found" after every rebuild, requiring manual rediscovery each session.

## Test plan
- [x] Fresh symlink creation: remove symlink, re-run `install_claude_plugin`, verify recreation
- [x] Idempotent re-run: run twice, no errors
- [x] `git check-ignore` confirms symlink is properly gitignored
- [x] 4-persona review (SWE/PM/QA/DevOps) — all issues addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)