### PR TITLE
fix: corvia-dev ingest command + post-start index check

### DIFF
--- a/.devcontainer/Taskfile.yml
+++ b/.devcontainer/Taskfile.yml
@@ -41,6 +41,7 @@ tasks:
       - cmd: "printf '\\033[1m=== Corvia Workspace: post-start ===\\033[0m\\n'"
       - task: post-start:parallel-setup
       - task: post-start:services
+      - task: post-start:check-index
       - task: post-start:claude-integration
       - task: post-start:ensure-extensions
       - task: post-start:optional-services
@@ -164,6 +165,28 @@ tasks:
         done
         printf ' FAILED\n' >&2
         exit 1
+
+  post-start:check-index:
+    desc: "Detect stale HNSW index and trigger rebuild if coverage < 90%"
+    cmds:
+      - |
+        source {{.SCRIPT_DIR}}/lib.sh
+        # Fetch index coverage from dashboard status API
+        RESP=$(curl -sf --max-time 5 http://127.0.0.1:{{.API_PORT}}/api/dashboard/status 2>/dev/null)
+        if [ -z "$RESP" ]; then
+          logw index "skipping index check (API unreachable)"
+          exit 0
+        fi
+        INDEX_STALE=$(echo "$RESP" | python3 -c "import sys,json; d=json.load(sys.stdin); print('true' if d.get('index_stale', False) else 'false')" 2>/dev/null)
+        COVERAGE=$(echo "$RESP" | python3 -c "import sys,json; d=json.load(sys.stdin); c=d.get('index_coverage'); print(f'{c:.1%}' if c is not None else 'unknown')" 2>/dev/null)
+        ENTRY_COUNT=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('entry_count', 0))" 2>/dev/null)
+        if [ "$INDEX_STALE" = "true" ]; then
+          logw index "stale index detected (coverage: $COVERAGE, indexed: $ENTRY_COUNT) — triggering rebuild"
+          curl -sf -X POST http://127.0.0.1:{{.API_PORT}}/v1/index/rebuild >/dev/null 2>&1 \
+            || logw index "rebuild request failed — run 'corvia-dev ingest' manually"
+        else
+          logm index "index OK (coverage: $COVERAGE, entries: $ENTRY_COUNT)"
+        fi
 
   # ── Claude Code integration ─────────────────────────────────────────
 

--- a/tools/corvia-dev/corvia_dev/cli.py
+++ b/tools/corvia-dev/corvia_dev/cli.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import signal
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -375,6 +376,80 @@ def logs(service: str | None, tail: int) -> None:
                 click.echo(line)
         if not found:
             click.echo("No log files found.")
+
+
+@main.command()
+@click.option("--fresh", is_flag=True, help="Re-index from scratch (pass --fresh to workspace ingest)")
+def ingest(fresh: bool) -> None:
+    """Stop server, run workspace ingest, then restart.
+
+    This works around the redb exclusive lock — the CLI and server cannot
+    both hold the database open at the same time.
+    """
+    # 1. Stop the manager (if running)
+    manager_was_running = False
+    if DEFAULT_STATE_PATH.exists():
+        try:
+            data = json.loads(DEFAULT_STATE_PATH.read_text())
+            resp = StatusResponse.model_validate(data)
+            if resp.manager and resp.manager.pid:
+                # Verify the process is actually alive before sending SIGTERM
+                try:
+                    os.kill(resp.manager.pid, 0)
+                except OSError:
+                    click.echo("Manager PID in state file is stale, skipping stop.")
+                else:
+                    click.echo("Stopping services...")
+                    os.kill(resp.manager.pid, signal.SIGTERM)
+                    manager_was_running = True
+                    # Poll for process death instead of blind sleep
+                    deadline = time.monotonic() + 15
+                    while time.monotonic() < deadline:
+                        try:
+                            os.kill(resp.manager.pid, 0)
+                            time.sleep(0.5)
+                        except OSError:
+                            break
+                    else:
+                        click.echo("Timed out waiting for manager to stop.", err=True)
+                        raise SystemExit(1)
+                    click.echo("Services stopped.")
+        except (json.JSONDecodeError, ValueError, ProcessLookupError):
+            pass
+
+    # 2. Run corvia workspace ingest
+    cmd = ["corvia", "workspace", "ingest"]
+    if fresh:
+        cmd.append("--fresh")
+
+    click.echo(f"Running: {' '.join(cmd)}")
+    try:
+        result = subprocess.run(cmd, cwd=str(_workspace_root()))
+    except FileNotFoundError:
+        click.echo("Error: 'corvia' binary not found on PATH.", err=True)
+        if manager_was_running:
+            click.echo("Restarting services...")
+            ctx = click.get_current_context()
+            ctx.invoke(up, no_foreground=True)
+        raise SystemExit(1)
+
+    if result.returncode != 0:
+        click.echo("Ingest failed.", err=True)
+        if manager_was_running:
+            click.echo("Restarting services despite ingest failure...")
+            ctx = click.get_current_context()
+            ctx.invoke(up, no_foreground=True)
+        raise SystemExit(1)
+
+    click.echo("Ingest complete.")
+
+    # 3. Restart services
+    if manager_was_running:
+        click.echo("Restarting services...")
+        ctx = click.get_current_context()
+        ctx.invoke(up, no_foreground=True)
+    else:
+        click.echo("Services were not running. Use 'corvia-dev up' to start.")
 
 
 @main.command()


### PR DESCRIPTION
## Summary
- Add `corvia-dev ingest [--fresh]` subcommand: stops server, runs `corvia workspace ingest`, restarts — works around redb exclusive lock
- Add `post-start:check-index` Taskfile task: queries dashboard status API, triggers HNSW rebuild when index coverage < 90%
- Uses poll-for-death (15s timeout) instead of blind sleep for reliable server shutdown

Depends on: chunzhe10/corvia#2 (index_coverage API fields)
Part of: [Operational Fixes Plan](docs/plans/2026-03-26-operational-fixes.md)

## Test plan
- [ ] Run `corvia-dev ingest` with server running — verify stop/ingest/restart cycle
- [ ] Run `corvia-dev ingest` with server not running — verify ingest runs and prints "Services were not running"
- [ ] Run `corvia-dev ingest --fresh` — verify `--fresh` flag is forwarded
- [ ] Verify `post-start:check-index` reports coverage when API is up
- [ ] Verify `post-start:check-index` gracefully skips when API is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)