### PR TITLE
chore: reduce devcontainer image from 20.9 GB to 10 GB (52% reduction)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     nodejs npm jq python3 sudo zstd \
     && rm -rf /var/lib/apt/lists/*
 
-# Intel GPU compute runtime (needed by Ollama for iGPU inference).
+# Intel GPU compute runtime (needed by corvia-inference OpenVINO EP for iGPU acceleration).
 # Packages aren't in Debian trixie repos — install from Intel's GitHub releases.
 # Only available for amd64; skip on other architectures.
 RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
@@ -86,8 +86,8 @@ RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
         echo "Skipping CUDA runtime packages (not amd64)"; \
     fi
 
-# Ollama (uses iGPU when /dev/dri is available, falls back to CPU)
-RUN curl -fsSL https://ollama.com/install.sh | sh
+# Ollama runs as a docker-compose sidecar (ollama/ollama image), not baked in.
+# See docker-compose.yml 'ollama' service with profiles: [ollama].
 
 # Docker CLI for Docker-outside-of-Docker (host socket mounted at /var/run/docker.sock).
 # Only the CLI is needed — the daemon runs on the host.

--- a/.devcontainer/Taskfile.yml
+++ b/.devcontainer/Taskfile.yml
@@ -272,16 +272,17 @@ tasks:
           exit 0
         fi
         source {{.SCRIPT_DIR}}/lib.sh
+        COMPOSE_CMD="docker compose -f .devcontainer/docker-compose.yml -f .devcontainer/docker-compose.override.yml --profile ollama"
         if grep -q "coding-llm=enabled" "{{.FLAGS_FILE}}"; then
-          if curl -sf http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then
-            if ! ollama list 2>/dev/null | grep -q "qwen2.5-coder:7b"; then
+          if curl -sf http://ollama:11434/api/tags >/dev/null 2>&1; then
+            if ! $COMPOSE_CMD exec ollama ollama list 2>/dev/null | grep -q "qwen2.5-coder:7b"; then
               printf "    pulling qwen2.5-coder:7b (first run only)"
-              ollama pull qwen2.5-coder:7b >/dev/null 2>&1 && printf "    ... done\n" || printf "    ... FAILED\n"
+              $COMPOSE_CMD exec ollama ollama pull qwen2.5-coder:7b >/dev/null 2>&1 && printf "    ... done\n" || printf "    ... FAILED\n"
             else
               echo "    ollama: qwen2.5-coder:7b already present"
             fi
           else
-            echo "    ... FAILED (ollama not reachable on :11434)" >&2
+            echo "    ... FAILED (ollama sidecar not reachable on ollama:11434)" >&2
           fi
         fi
         if ! grep -qE "(coding-llm)=enabled" "{{.FLAGS_FILE}}"; then

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,10 +8,11 @@
     "initializeCommand": ".devcontainer/scripts/init-host.sh",
     "postCreateCommand": "python3 .devcontainer/scripts/setup_wrapper.py post-create",
     "postStartCommand": "python3 .devcontainer/scripts/setup_wrapper.py post-start",
-    // 8020: corvia REST+MCP+dashboard (embedded), 8030: inference gRPC, 11434: ollama
+    // 8020: corvia REST+MCP+dashboard (embedded), 8030: inference gRPC
     // 8021: Vite dev server — only used during dashboard frontend development
     // 8050 (playwright-mcp) is container-internal only — not forwarded.
-    "forwardPorts": [8020, 8021, 8030, 11434],
+    // 11434 (ollama) is on the ollama sidecar container, port-mapped in docker-compose.override.yml.
+    "forwardPorts": [8020, 8021, 8030],
     "mounts": [
         "source=${localEnv:HOME}${localEnv:USERPROFILE}/.config/gh,target=/root/.config/gh-host,type=bind,consistency=cached,readonly",
         "source=${localEnv:HOME}${localEnv:USERPROFILE}/.claude,target=/root/.claude,type=bind,consistency=cached"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,6 +13,16 @@ services:
       # Image builds go into the host's registry. The host socket path must exist.
       - /var/run/docker.sock:/var/run/docker.sock
 
+  ollama:
+    image: ollama/ollama:latest
+    profiles: [ollama]  # only starts when explicitly activated
+    environment:
+      - OLLAMA_HOST=0.0.0.0:11434
+    volumes:
+      - corvia-ollama-models:/root/.ollama
+    # GPU passthrough and ports injected by docker-compose.override.yml
+
 volumes:
   corvia-cargo-registry:
   corvia-cargo-git:
+  corvia-ollama-models:

--- a/.devcontainer/scripts/init-host.sh
+++ b/.devcontainer/scripts/init-host.sh
@@ -241,11 +241,17 @@ fi
     echo "  app:"
 
     # Port mapping (always emitted — maps host ports to fixed container ports)
+    # Ollama port is on the ollama sidecar service, not the app container.
     echo "    ports:"
     echo "      - \"$HOST_API:8020\""
     echo "      - \"$HOST_VITE:8021\""
     echo "      - \"$HOST_INFERENCE:8030\""
-    echo "      - \"$HOST_OLLAMA:11434\""
+
+    # Collect devices, groups, and volumes into arrays — initialized before the
+    # GPU conditional so they exist for both the app and ollama stanzas.
+    DEVICES=()
+    GROUP_ADD=()
+    VOLUMES=()
 
     if [ "$HAS_NVIDIA" = false ] && [ "$HAS_DRI" = false ] && [ "$HAS_DXG" = false ]; then
         GPU_SUMMARY="No GPU detected — running CPU-only"
@@ -253,11 +259,6 @@ fi
     else
         GPU_SUMMARY="nvidia=$HAS_NVIDIA dri=$HAS_DRI wsl_dxg=$HAS_DXG"
         echo "    # GPU: $GPU_SUMMARY"
-
-        # Collect devices, groups, and volumes into arrays (emitted once each)
-        DEVICES=()
-        GROUP_ADD=()
-        VOLUMES=()
 
         if [ "$HAS_DRI" = true ]; then
             DEVICES+=("/dev/dri:/dev/dri")
@@ -307,6 +308,39 @@ fi
         fi
 
         # NVIDIA container toolkit (uses deploy.resources for compose v2)
+        if [ "$HAS_NVIDIA" = true ]; then
+            echo "    deploy:"
+            echo "      resources:"
+            echo "        reservations:"
+            echo "          devices:"
+            echo "            - driver: nvidia"
+            echo "              count: all"
+            echo "              capabilities: [gpu]"
+        fi
+    fi
+
+    # ── Ollama sidecar GPU passthrough ────────────────────────────────
+    # The ollama service (docker-compose.yml, profiles: [ollama]) needs the
+    # same GPU access as the app container for accelerated inference.
+    echo ""
+    echo "  ollama:"
+    echo "    ports:"
+    echo "      - \"$HOST_OLLAMA:11434\""
+
+    if [ "$HAS_NVIDIA" = true ] || [ "$HAS_DRI" = true ] || [ "$HAS_DXG" = true ]; then
+        # Reuse the same device/group arrays built for the app container
+        if [ ${#DEVICES[@]} -gt 0 ]; then
+            echo "    devices:"
+            for d in "${DEVICES[@]}"; do
+                echo "      - $d"
+            done
+        fi
+        if [ ${#GROUP_ADD[@]} -gt 0 ]; then
+            echo "    group_add:"
+            for g in "${GROUP_ADD[@]}"; do
+                echo "      - $g"
+            done
+        fi
         if [ "$HAS_NVIDIA" = true ]; then
             echo "    deploy:"
             echo "      resources:"

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -55,4 +55,4 @@ fi
 echo ""
 echo "=== post-create complete ==="
 echo "Run 'corvia-dev status' to see available services."
-echo "Run 'corvia-dev use ollama' to switch to Ollama embeddings."
+echo "Run 'corvia-dev use ollama' to switch to Ollama embeddings (starts sidecar container)."

--- a/tools/corvia-dev/corvia_dev/config.py
+++ b/tools/corvia-dev/corvia_dev/config.py
@@ -12,7 +12,7 @@ import tomli_w
 PROVIDER_MAP: dict[str, dict[str, str]] = {
     "ollama": {
         "provider": "ollama",
-        "url": "http://127.0.0.1:11434",
+        "url": "http://ollama:11434",  # Docker Compose service name
     },
     "corvia-inference": {
         "provider": "corvia",

--- a/tools/corvia-dev/corvia_dev/health.py
+++ b/tools/corvia-dev/corvia_dev/health.py
@@ -72,7 +72,7 @@ def check_service(svc: ServiceDefinition, timeout: float = 3.0) -> HealthResult:
     """Check health of a service. Dispatches to appropriate check method."""
     if svc.port is None or svc.health_proto == "none":
         return HealthResult(healthy=None, latency_ms=-1)
-    host = "127.0.0.1"
+    host = svc.health_host
     if svc.health_proto == "grpc":
         return check_grpc(host, svc.port, timeout=timeout)
     if svc.health_proto == "tcp":

--- a/tools/corvia-dev/corvia_dev/manager.py
+++ b/tools/corvia-dev/corvia_dev/manager.py
@@ -155,12 +155,25 @@ class ProcessManager:
                 stderr=fh,
                 start_new_session=True,  # own process group so we can kill children
             )
-            mp.process = proc
-            mp.pid = proc.pid
-            mp.started_at = time.time()
-            mp.state = ServiceState.STARTING
-            mp._log_fh = fh  # keep reference so GC doesn't close it
-            self._log(f"{name}: started (pid {proc.pid}), logs -> {log_file}")
+
+            # Docker-managed services (stop_cmd set) run detached: the process
+            # exits immediately after `docker compose up -d`. Don't track the
+            # process — health checks will promote to HEALTHY.
+            if mp.service.stop_cmd:
+                await proc.wait()
+                fh.close()
+                mp.process = None
+                mp.pid = None
+                mp.started_at = time.time()
+                mp.state = ServiceState.STARTING
+                self._log(f"{name}: docker-managed service launched, waiting for health")
+            else:
+                mp.process = proc
+                mp.pid = proc.pid
+                mp.started_at = time.time()
+                mp.state = ServiceState.STARTING
+                mp._log_fh = fh  # keep reference so GC doesn't close it
+                self._log(f"{name}: started (pid {proc.pid}), logs -> {log_file}")
         except FileNotFoundError:
             mp.state = ServiceState.CRASHED
             self._log(f"{name}: binary not found")
@@ -171,7 +184,28 @@ class ProcessManager:
     async def stop_service(self, name: str) -> None:
         """Stop a single service process."""
         mp = self.processes.get(name)
-        if mp is None or mp.process is None:
+        if mp is None:
+            return
+
+        # Docker-managed services: run stop_cmd instead of kill-by-PID
+        if mp.service.stop_cmd:
+            self._log(f"{name}: stopping (docker-managed)")
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    *mp.service.stop_cmd,
+                    cwd=str(self.workspace_root),
+                )
+                await asyncio.wait_for(proc.wait(), timeout=30.0)
+            except (asyncio.TimeoutError, OSError) as e:
+                self._log(f"{name}: stop command failed: {e}")
+            mp.state = ServiceState.STOPPED
+            mp.pid = None
+            mp.process = None
+            mp.started_at = None
+            self._log(f"{name}: stopped")
+            return
+
+        if mp.process is None:
             return
 
         self._log(f"{name}: stopping (pid {mp.pid})")
@@ -207,12 +241,16 @@ class ProcessManager:
             if mp.state in (ServiceState.STOPPED,):
                 continue
 
+            # Process-managed services: check if the child died
             if mp.process is not None and mp.process.returncode is not None:
                 mp.state = ServiceState.CRASHED
                 mp.pid = None
                 self._log(f"{name}: crashed (exit code {mp.process.returncode})")
                 mp.process = None
                 continue
+
+            # Docker-managed services have no local process — skip crash detection
+            # and rely purely on health checks below
 
             result = check_service(mp.service)
             if result.healthy is True:

--- a/tools/corvia-dev/corvia_dev/models.py
+++ b/tools/corvia-dev/corvia_dev/models.py
@@ -26,7 +26,9 @@ class ServiceDefinition(BaseModel):
     health_path: str = "/health"
     health_proto: str = "http"  # "http", "grpc", "tcp", or "none"
     start_cmd: list[str] = []
+    stop_cmd: list[str] = []  # if non-empty, run this instead of kill-by-PID (for docker-managed services)
     stop_signal: str = "SIGTERM"
+    health_host: str = "127.0.0.1"  # override for services on Docker network (e.g. "ollama")
     depends_on: list[str] = []
     exclusive_group: str | None = None
 

--- a/tools/corvia-dev/corvia_dev/services.py
+++ b/tools/corvia-dev/corvia_dev/services.py
@@ -30,7 +30,21 @@ SERVICES: list[ServiceDefinition] = [
         tier=1,
         port=11434,
         health_path="/api/tags",
-        start_cmd=["ollama", "serve"],
+        health_host="ollama",  # Docker Compose service name
+        start_cmd=[
+            "docker", "compose",
+            "-f", ".devcontainer/docker-compose.yml",
+            "-f", ".devcontainer/docker-compose.override.yml",
+            "--profile", "ollama",
+            "up", "-d", "ollama",
+        ],
+        stop_cmd=[
+            "docker", "compose",
+            "-f", ".devcontainer/docker-compose.yml",
+            "-f", ".devcontainer/docker-compose.override.yml",
+            "--profile", "ollama",
+            "stop", "ollama",
+        ],
         depends_on=[],
         exclusive_group="embedding",
     ),

--- a/tools/corvia-dev/tests/test_config.py
+++ b/tools/corvia-dev/tests/test_config.py
@@ -53,11 +53,11 @@ def test_use_ollama(tmp_path: Path) -> None:
 
     raw = tomllib.loads(toml_path.read_text())
     assert raw["embedding"]["provider"] == "ollama"
-    assert raw["embedding"]["url"] == "http://127.0.0.1:11434"
+    assert raw["embedding"]["url"] == "http://ollama:11434"
     assert raw["embedding"]["model"] == "nomic-embed-text-v1.5"
     assert raw["embedding"]["dimensions"] == 768
     assert raw["merge"]["provider"] == "ollama"
-    assert raw["merge"]["url"] == "http://127.0.0.1:11434"
+    assert raw["merge"]["url"] == "http://ollama:11434"
     assert raw["project"]["name"] == "test"
     assert raw["server"]["port"] == 8020
     assert len(raw["workspace"]["repos"]) == 1


### PR DESCRIPTION
## Summary

Reduces the devcontainer Docker image from **20.9 GB to 10 GB** (52% reduction) via two phases:

### Phase 1 — Cache cleanup and dead-weight removal (-2.7 GB)
- **Remove unused playwright COPY** (-1.07 GB): `COPY --from=playwright /ms-playwright` brought 1 GB of browser binaries unused at runtime. Chrome installs independently to `/opt/google/chrome`.
- **Clean CUDA pip cache** (-580 MB): `uv pip install` left `/root/.cache/uv` in the layer.
- **Clean npm cache** (-120 MB): Added `rm -rf /root/.npm` after global installs.
- **Combine npm RUN steps**: claude-code + vsce in single layer.

### Phase 2 — Ollama sidecar migration (-8.2 GB)
- **Remove Ollama from Dockerfile** (-5 GB baked-in install including bundled CUDA libs)
- **Add Ollama as docker-compose sidecar**: `ollama/ollama:latest` with `profiles: [ollama]`
- **GPU passthrough**: init-host.sh generates device/NVIDIA config for both app and ollama services
- **Model persistence**: `corvia-ollama-models` named Docker volume
- **corvia-dev integration**: Manager handles docker-managed service lifecycle (detached start, compose stop, DNS health checks)
- **Opt-in activation**: `corvia-dev use ollama` starts the sidecar container

## Files Changed

| Area | Files | What |
|------|-------|------|
| Dockerfile | `.devcontainer/Dockerfile` | Remove Ollama install, clean caches, remove playwright COPY |
| Compose | `docker-compose.yml` | Add ollama sidecar with profile gate + model volume |
| Host init | `init-host.sh` | GPU passthrough for ollama sidecar, port mapping |
| corvia-dev | `services.py`, `manager.py`, `models.py`, `config.py`, `health.py` | Docker-managed service lifecycle, DNS health checks |
| Config | `devcontainer.json`, `Taskfile.yml`, `post-create.sh` | Port/command updates |
| Tests | `test_config.py` | Updated URL assertions |

## Verification

| Check | Result |
|-------|--------|
| `python3 -c "import nvidia.cublas"` | OK |
| `google-chrome --headless --no-sandbox --dump-dom` | OK |
| `command -v ollama` (should not exist) | OK (removed) |
| corvia-dev test suite (39 tests) | All passing |
| Image size | **10 GB** (was 20.9 GB) |

## Test plan

- [ ] Rebuild devcontainer from scratch, verify all services start (`corvia-dev up`)
- [ ] Verify `corvia-dev use ollama` starts the sidecar and embedding works
- [ ] Verify `corvia-dev down` stops both app and ollama containers
- [ ] Verify GPU passthrough to ollama sidecar (on GPU-equipped host)
- [ ] Verify model persistence: pull model, rebuild, check model still present

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)