### PR TITLE
chore(devcontainer): use Claude Code native installer instead of npm

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -127,8 +127,13 @@ RUN { curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && rm -rf /var/lib/apt/lists/*; } \
     || { rm -rf /var/lib/apt/lists/*; echo "WARNING: gh CLI install failed — will retry at runtime"; }
 
-RUN { npm install -g --silent @anthropic-ai/claude-code \
-    && npm install -g --silent @vscode/vsce; } \
+# Claude Code: native installer (npm path is deprecated upstream).
+# Installs to /root/.local/bin/claude with built-in auto-updates.
+RUN { curl -fsSL https://claude.ai/install.sh | bash; } \
+    || echo "WARNING: claude native install failed — will retry at runtime"
+ENV PATH="/root/.local/bin:${PATH}"
+
+RUN { npm install -g --silent @vscode/vsce; } \
     || echo "WARNING: npm global install failed — will retry at runtime"; \
     rm -rf /root/.npm
 


### PR DESCRIPTION
## Summary
- npm global install of `@anthropic-ai/claude-code` is deprecated upstream and prints a warning on every invocation
- Switch the devcontainer Dockerfile to the official native installer (`https://claude.ai/install.sh`)
- Add `/root/.local/bin` to `PATH` so the installed binary is discoverable; the binary self-updates from there
- `@vscode/vsce` stays on npm — it's unaffected

## Test plan
- [ ] Rebuild the devcontainer
- [ ] `which claude` resolves to `/root/.local/bin/claude`
- [ ] `claude --version` prints a version with no npm-deprecation warning
- [ ] Existing `~/.claude` bind mount and superpowers plugin install (post-start) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)