### PR TITLE
fix: make MCP access loud on failure; adopt v1.0.1 minimum

### DIFF
--- a/.devcontainer/Taskfile.yml
+++ b/.devcontainer/Taskfile.yml
@@ -32,9 +32,11 @@ tasks:
       - cmd: "printf '\\033[1m=== Corvia Workspace: post-start ===\\033[0m\\n'"
       - task: post-start:auth
       - task: post-start:corvia-init
-      - task: post-start:corvia-serve
       - task: post-start:claude-integration
       - task: post-start:sweep
+      # corvia-serve runs last: hard-failure on missing `serve` subcommand
+      # must not prevent claude-integration + sweep from completing.
+      - task: post-start:corvia-serve
       - cmd: "printf '\\n\\033[1;32m✓ Ready.\\033[0m\\n'"
 
   post-start:auth:
@@ -66,27 +68,32 @@ tasks:
         if ! corvia serve --help >/dev/null 2>&1; then
           tag="$(cat /usr/local/share/corvia-release-tag 2>/dev/null || echo unknown)"
           loge services "corvia serve: not supported by installed binary (tag=$tag)"
-          loge services "this workspace requires a serve-capable binary (corvia >= v1.0.2)"
-          loge services "remediation: task post-create:install-binary  (or rebuild devcontainer)"
+          loge services "this workspace requires a serve-capable binary (corvia >= v1.0.1)"
+          loge services "remediation: python3 .devcontainer/scripts/install_corvia.py  (or rebuild devcontainer)"
           exit 1
         fi
-        # 2. Already-running check — idempotent: exit 0 if :8020 already listening.
-        if bash -c ': > /dev/tcp/127.0.0.1/8020' 2>/dev/null; then
+        # 2. Already-running check — probe /healthz, not raw TCP, so we confirm
+        # the running process is actually a healthy corvia serve.
+        if curl -sf --max-time 2 http://127.0.0.1:8020/healthz >/dev/null 2>&1; then
           logg services "corvia serve: already running on port 8020"
           exit 0
         fi
-        # 3. Start server in background.
+        # 3. Rotate log: keep one previous boot for post-mortem.
+        if [ -f {{.WORKSPACE_ROOT}}/.corvia/serve.log ]; then
+          mv -f {{.WORKSPACE_ROOT}}/.corvia/serve.log {{.WORKSPACE_ROOT}}/.corvia/serve.log.prev
+        fi
+        # 4. Start server in background.
         logg services "corvia serve: starting on port 8020"
-        nohup corvia serve --port 8020 >> {{.WORKSPACE_ROOT}}/.corvia/serve.log 2>&1 &
-        # 4. Health probe — 5s budget; hard-fail if TCP never opens.
+        nohup corvia serve --port 8020 > {{.WORKSPACE_ROOT}}/.corvia/serve.log 2>&1 &
+        # 5. Health probe — 5s budget; hard-fail if /healthz never answers.
         for i in 1 2 3 4 5; do
           sleep 1
-          if bash -c ': > /dev/tcp/127.0.0.1/8020' 2>/dev/null; then
+          if curl -sf --max-time 2 http://127.0.0.1:8020/healthz >/dev/null 2>&1; then
             logg services "corvia serve: ready (${i}s)"
             exit 0
           fi
         done
-        loge services "corvia serve: not responding after 5s — check .corvia/serve.log"
+        loge services "corvia serve: /healthz not responding after 5s — check .corvia/serve.log"
         exit 1
 
   post-start:claude-integration:

--- a/.devcontainer/Taskfile.yml
+++ b/.devcontainer/Taskfile.yml
@@ -66,8 +66,8 @@ tasks:
         # 1. Capability guard — fail loudly if binary lacks `serve`.
         # Workspace requires HTTP MCP; stdio is deprecated here.
         if ! corvia serve --help >/dev/null 2>&1; then
-          tag="$(cat /usr/local/share/corvia-release-tag 2>/dev/null || echo unknown)"
-          loge services "corvia serve: not supported by installed binary (tag=$tag)"
+          tag="$(cat /usr/local/share/corvia-release-tag 2>/dev/null || true)"
+          loge services "corvia serve: not supported by installed binary (tag=${tag:-unknown})"
           loge services "this workspace requires a serve-capable binary (corvia >= v1.0.1)"
           loge services "remediation: python3 .devcontainer/scripts/install_corvia.py  (or rebuild devcontainer)"
           exit 1
@@ -85,15 +85,16 @@ tasks:
         # 4. Start server in background.
         logg services "corvia serve: starting on port 8020"
         nohup corvia serve --port 8020 > {{.WORKSPACE_ROOT}}/.corvia/serve.log 2>&1 &
-        # 5. Health probe — 5s budget; hard-fail if /healthz never answers.
-        for i in 1 2 3 4 5; do
+        # 5. Health probe — 30s budget accommodates first-boot embedder download
+        # (~17s observed for nomic-embed-text-v1.5). Hard-fail if /healthz never answers.
+        for i in $(seq 1 30); do
           sleep 1
           if curl -sf --max-time 2 http://127.0.0.1:8020/healthz >/dev/null 2>&1; then
             logg services "corvia serve: ready (${i}s)"
             exit 0
           fi
         done
-        loge services "corvia serve: /healthz not responding after 5s — check .corvia/serve.log"
+        loge services "corvia serve: /healthz not responding after 30s — check .corvia/serve.log"
         exit 1
 
   post-start:claude-integration:

--- a/.devcontainer/Taskfile.yml
+++ b/.devcontainer/Taskfile.yml
@@ -61,20 +61,24 @@ tasks:
     cmds:
       - |
         source {{.SCRIPT_DIR}}/lib.sh
-        # 1. Capability guard — skip if binary doesn't support serve
+        # 1. Capability guard — fail loudly if binary lacks `serve`.
+        # Workspace requires HTTP MCP; stdio is deprecated here.
         if ! corvia serve --help >/dev/null 2>&1; then
-          logw services "corvia serve: not supported by installed binary — skipping"
-          exit 0
+          tag="$(cat /usr/local/share/corvia-release-tag 2>/dev/null || echo unknown)"
+          loge services "corvia serve: not supported by installed binary (tag=$tag)"
+          loge services "this workspace requires a serve-capable binary (corvia >= v1.0.2)"
+          loge services "remediation: task post-create:install-binary  (or rebuild devcontainer)"
+          exit 1
         fi
-        # 2. Already-running check — skip if port 8020 is already listening
+        # 2. Already-running check — idempotent: exit 0 if :8020 already listening.
         if bash -c ': > /dev/tcp/127.0.0.1/8020' 2>/dev/null; then
           logg services "corvia serve: already running on port 8020"
           exit 0
         fi
-        # 3. Start server in background
+        # 3. Start server in background.
         logg services "corvia serve: starting on port 8020"
         nohup corvia serve --port 8020 >> {{.WORKSPACE_ROOT}}/.corvia/serve.log 2>&1 &
-        # 4. Health probe — wait up to 5s for TCP connection
+        # 4. Health probe — 5s budget; hard-fail if TCP never opens.
         for i in 1 2 3 4 5; do
           sleep 1
           if bash -c ': > /dev/tcp/127.0.0.1/8020' 2>/dev/null; then
@@ -82,7 +86,8 @@ tasks:
             exit 0
           fi
         done
-        logw services "corvia serve: not responding after 5s — check .corvia/serve.log"
+        loge services "corvia serve: not responding after 5s — check .corvia/serve.log"
+        exit 1
 
   post-start:claude-integration:
     desc: "Install superpowers plugin"

--- a/.devcontainer/scripts/lib.sh
+++ b/.devcontainer/scripts/lib.sh
@@ -22,6 +22,10 @@ logw() {
     local mod="$1"; shift
     printf '\033[33m[%s]\033[0m %s\n' "$mod" "$*"
 }
+loge() {
+    local mod="$1"; shift
+    printf '\033[31m[%s]\033[0m %s\n' "$mod" "$*" >&2
+}
 
 # Retry a command up to N times with exponential backoff.
 # Usage: retry <max_attempts> command args...

--- a/.devcontainer/scripts/post-start.sh
+++ b/.devcontainer/scripts/post-start.sh
@@ -31,7 +31,11 @@ fi
 # ── 3/5 ───────────────────────────────────────────────────────────────
 step "Starting corvia serve"
 if ! corvia serve --help >/dev/null 2>&1; then
-    echo "    corvia serve: not supported by installed binary — skipping"
+    _tag="$(cat /usr/local/share/corvia-release-tag 2>/dev/null || echo unknown)"
+    fail_msg "corvia serve: not supported by installed binary (tag=$_tag)"
+    fail_msg "this workspace requires a serve-capable binary (corvia >= v1.0.2)"
+    fail_msg "remediation: python3 .devcontainer/scripts/install_corvia.py  (or rebuild devcontainer)"
+    exit 1
 elif bash -c ': > /dev/tcp/127.0.0.1/8020' 2>/dev/null; then
     echo "    already running on port 8020"
 else
@@ -45,7 +49,10 @@ else
             break
         fi
     done
-    [ "$_ready" -eq 0 ] && fail_msg "not responding after 5s — check .corvia/serve.log"
+    if [ "$_ready" -eq 0 ]; then
+        fail_msg "corvia serve: not responding after 5s — check .corvia/serve.log"
+        exit 1
+    fi
 fi
 
 # ── 4/5 ───────────────────────────────────────────────────────────────

--- a/.devcontainer/scripts/post-start.sh
+++ b/.devcontainer/scripts/post-start.sh
@@ -29,41 +29,47 @@ else
 fi
 
 # ── 3/5 ───────────────────────────────────────────────────────────────
+step "Claude Code integration"
+printf "    superpowers plugin: "
+install_claude_plugin "https://github.com/obra/superpowers.git" superpowers claude-plugins-official \
+    || fail_msg "git clone failed — check network connectivity"
+
+# ── 4/5 ───────────────────────────────────────────────────────────────
+# Sweep cargo build artifacts if disk is >70% full.
+"$SCRIPT_DIR/sweep-cargo-cache.sh" || true
+
+# ── 5/5 ───────────────────────────────────────────────────────────────
+# corvia-serve runs last: hard-failure on missing `serve` must not skip
+# the steps above (superpowers install, cache sweep).
 step "Starting corvia serve"
 if ! corvia serve --help >/dev/null 2>&1; then
     _tag="$(cat /usr/local/share/corvia-release-tag 2>/dev/null || echo unknown)"
     fail_msg "corvia serve: not supported by installed binary (tag=$_tag)"
-    fail_msg "this workspace requires a serve-capable binary (corvia >= v1.0.2)"
+    fail_msg "this workspace requires a serve-capable binary (corvia >= v1.0.1)"
     fail_msg "remediation: python3 .devcontainer/scripts/install_corvia.py  (or rebuild devcontainer)"
     exit 1
-elif bash -c ': > /dev/tcp/127.0.0.1/8020' 2>/dev/null; then
+elif curl -sf --max-time 2 http://127.0.0.1:8020/healthz >/dev/null 2>&1; then
     echo "    already running on port 8020"
 else
-    nohup corvia serve --port 8020 >> "$WORKSPACE_ROOT/.corvia/serve.log" 2>&1 &
+    # Rotate log: keep one previous boot for post-mortem.
+    if [ -f "$WORKSPACE_ROOT/.corvia/serve.log" ]; then
+        mv -f "$WORKSPACE_ROOT/.corvia/serve.log" "$WORKSPACE_ROOT/.corvia/serve.log.prev"
+    fi
+    nohup corvia serve --port 8020 > "$WORKSPACE_ROOT/.corvia/serve.log" 2>&1 &
     _ready=0
     for i in 1 2 3 4 5; do
         sleep 1
-        if bash -c ': > /dev/tcp/127.0.0.1/8020' 2>/dev/null; then
+        if curl -sf --max-time 2 http://127.0.0.1:8020/healthz >/dev/null 2>&1; then
             echo "    ready (${i}s)"
             _ready=1
             break
         fi
     done
     if [ "$_ready" -eq 0 ]; then
-        fail_msg "corvia serve: not responding after 5s — check .corvia/serve.log"
+        fail_msg "corvia serve: /healthz not responding after 5s — check .corvia/serve.log"
         exit 1
     fi
 fi
-
-# ── 4/5 ───────────────────────────────────────────────────────────────
-step "Claude Code integration"
-printf "    superpowers plugin: "
-install_claude_plugin "https://github.com/obra/superpowers.git" superpowers claude-plugins-official \
-    || fail_msg "git clone failed — check network connectivity"
-
-# ── 5/5 ───────────────────────────────────────────────────────────────
-# Sweep cargo build artifacts if disk is >70% full.
-"$SCRIPT_DIR/sweep-cargo-cache.sh" || true
 
 echo ""
 echo "Ready."

--- a/.devcontainer/scripts/post-start.sh
+++ b/.devcontainer/scripts/post-start.sh
@@ -43,8 +43,8 @@ install_claude_plugin "https://github.com/obra/superpowers.git" superpowers clau
 # the steps above (superpowers install, cache sweep).
 step "Starting corvia serve"
 if ! corvia serve --help >/dev/null 2>&1; then
-    _tag="$(cat /usr/local/share/corvia-release-tag 2>/dev/null || echo unknown)"
-    fail_msg "corvia serve: not supported by installed binary (tag=$_tag)"
+    _tag="$(cat /usr/local/share/corvia-release-tag 2>/dev/null || true)"
+    fail_msg "corvia serve: not supported by installed binary (tag=${_tag:-unknown})"
     fail_msg "this workspace requires a serve-capable binary (corvia >= v1.0.1)"
     fail_msg "remediation: python3 .devcontainer/scripts/install_corvia.py  (or rebuild devcontainer)"
     exit 1
@@ -57,7 +57,8 @@ else
     fi
     nohup corvia serve --port 8020 > "$WORKSPACE_ROOT/.corvia/serve.log" 2>&1 &
     _ready=0
-    for i in 1 2 3 4 5; do
+    # 30s budget accommodates first-boot embedder download (~17s observed).
+    for i in $(seq 1 30); do
         sleep 1
         if curl -sf --max-time 2 http://127.0.0.1:8020/healthz >/dev/null 2>&1; then
             echo "    ready (${i}s)"
@@ -66,7 +67,7 @@ else
         fi
     done
     if [ "$_ready" -eq 0 ]; then
-        fail_msg "corvia serve: /healthz not responding after 5s — check .corvia/serve.log"
+        fail_msg "corvia serve: /healthz not responding after 30s — check .corvia/serve.log"
         exit 1
     fi
 fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,12 +27,11 @@ corvia-workspace/
 ## Quick Reference
 
 ```bash
-corvia workspace status          # Check workspace + service health
+corvia status                   # Check indexed entries + recent traces
 corvia search "query"            # Search ingested knowledge
-corvia workspace ingest          # Index all repos
-corvia workspace ingest --fresh  # Re-index from scratch
+corvia ingest                   # Index the current workspace
+corvia ingest --fresh            # Re-index from scratch
 corvia serve &                   # Start server (auto-started by devcontainer)
-corvia workspace init-hooks      # Generate doc-placement hooks from config
 ```
 
 ## MCP Server (Dogfooding)

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ pre-configured — services start automatically.
 ```bash
 git clone https://github.com/chunzhe10/corvia-workspace
 cd corvia-workspace
-corvia workspace init          # clones repos, sets up config
-corvia workspace ingest        # indexes all repos
-corvia serve &                 # start API + MCP server
+corvia init --yes              # initialize .corvia/ store
+corvia ingest                  # index the current workspace
+corvia serve &                 # start HTTP MCP server on :8020
 corvia search "how does chunking work"
 ```
 
@@ -58,11 +58,11 @@ no Ollama required.
 corvia search "IngestionAdapter"          # finds trait + implementation
 corvia search "how does embedding work"   # surfaces pipeline from kernel
 corvia search "tree-sitter chunking"      # finds adapter's AST parsing
-corvia workspace status                   # see workspace + service health
+corvia status                             # indexed entries + recent traces
 ```
 
 ## Fresh ingest
 
 ```bash
-corvia workspace ingest --fresh
+corvia ingest --fresh
 ```

--- a/docs/decisions/2026-04-17-mcp-access-http-default-design.md
+++ b/docs/decisions/2026-04-17-mcp-access-http-default-design.md
@@ -1,0 +1,124 @@
+# MCP access: HTTP as default, stdio deprecated
+
+**Date:** 2026-04-17
+**Status:** Approved
+**Scope:** `.devcontainer/.mcp.json`, `.devcontainer/Taskfile.yml`, `.devcontainer/scripts/post-start.sh`, `CLAUDE.md`, `AGENTS.md`
+
+## Problem
+
+`.mcp.json` at the workspace root declares HTTP MCP transport at
+`http://127.0.0.1:8020/mcp`. The installed/released `corvia` binary is v1.0.0,
+which lacks the `corvia serve` subcommand — that subcommand landed on corvia
+master **after** v1.0.0 was tagged.
+
+The devcontainer's `post-start:corvia-serve` task has a capability guard that
+runs `corvia serve --help` and, if the subcommand is missing, logs a warning and
+exits 0 (silent skip). The result: no HTTP server runs, `.mcp.json` points at a
+dead URL, Claude Code starts with zero corvia MCP tools, and nothing visibly
+fails.
+
+Evidence that a previous mid-fix happened: `.devcontainer/.mcp.json` (untracked)
+contains a stdio-based `corvia mcp` config — a local workaround that was never
+committed.
+
+Secondary issue: `CLAUDE.md` and `AGENTS.md` reference `corvia workspace status`,
+`corvia workspace ingest`, and `corvia workspace init-hooks`. No `workspace`
+subcommand exists in the corvia CLI — these are stale and misleading.
+
+## Decision
+
+**HTTP is the default and only supported MCP transport in this workspace.**
+Stdio is deprecated here. The workspace fix is the config + hardening half of
+the story; the release-side half (cutting v1.0.2 with the `serve` subcommand)
+is tracked separately by the maintainer.
+
+## Design
+
+### Changes
+
+| File | Change |
+|------|--------|
+| `.devcontainer/.mcp.json` | Delete (untracked stdio workaround). |
+| `.devcontainer/Taskfile.yml` (`post-start:corvia-serve`) | Replace silent-skip capability guard with loud failure: print installed release tag, required minimum (`≥ v1.0.2`), actionable remediation, exit non-zero. Also promote the 5-second TCP-probe timeout from warning to hard failure. |
+| `.devcontainer/scripts/post-start.sh` | Apply the same loud-failure contract to the bash-fallback equivalent, if present. |
+| `CLAUDE.md` | Remove/correct `corvia workspace ...` references. |
+| `AGENTS.md` | Same — the Quick Reference section lists nonexistent `corvia workspace` commands. |
+
+### Loud-failure contract
+
+Current behavior in `post-start:corvia-serve`:
+
+```bash
+if ! corvia serve --help >/dev/null 2>&1; then
+  logw services "corvia serve: not supported by installed binary — skipping"
+  exit 0   # ← silent skip; root cause of invisible breakage
+fi
+```
+
+Replacement:
+
+```bash
+if ! corvia serve --help >/dev/null 2>&1; then
+  tag="$(cat /usr/local/share/corvia-release-tag 2>/dev/null || echo unknown)"
+  loge services "corvia serve: not supported by installed binary (tag=$tag)"
+  loge services "this workspace requires a serve-capable binary (corvia >= v1.0.2)"
+  loge services "remediation: task post-create:install-binary  (or rebuild devcontainer)"
+  exit 1
+fi
+```
+
+If `lib.sh` has no `loge` helper, use `logw` style with redirection to stderr +
+explicit `exit 1`.
+
+The TCP-probe loop that currently only warns ("corvia serve: not responding
+after 5s") becomes a hard failure: serve-started-but-dead must be visible, not
+silently masqueraded as success.
+
+### What stays the same
+
+- `.mcp.json` at the workspace root — already HTTP, already correct.
+- `.devcontainer/scripts/install_corvia.py` — "latest release" behavior is fine;
+  v1.0.2 will flow in once the maintainer cuts it.
+- `corvia mcp` stdio subcommand in `repos/corvia/` — out of scope; stdio is
+  deprecated at the workspace level, not removed from the binary.
+
+### Non-goals
+
+- Dynamic `.mcp.json` rewriting at post-start.
+- Installer-side minimum-version pin (would create a merge-order hazard with
+  v1.0.2 tagging).
+- Removing `corvia mcp` from the CLI.
+
+## Consequences
+
+**Positive:**
+- Post-start no longer silently masks the broken MCP path. Any future
+  regression in binary capability will surface immediately.
+- `.mcp.json` remains deterministic and checked in.
+- Workspace docs stop advertising commands that don't exist.
+
+**Negative / accepted:**
+- Until v1.0.2 is released, a fresh devcontainer rebuild will fail at post-start
+  unless someone manually installs a serve-capable binary (e.g., `cargo build`
+  + copy per the `CLAUDE.md` workaround). This is the intended tradeoff: loud
+  failure over invisible breakage.
+
+**Ordering:**
+- This PR can merge before v1.0.2 is tagged. Users with an existing working
+  devcontainer are unaffected (post-start only fails on rebuild). New
+  containers built before v1.0.2 lands will see a clear error; the user cuts
+  v1.0.2 and a rebuild picks it up.
+
+## Testing
+
+- **Config parse**: `task --dry post-start:corvia-serve` parses cleanly.
+- **Missing-serve path**: place a pre-v1.0.2 binary at `/usr/local/bin/corvia`;
+  run the task; assert non-zero exit, stderr contains `v1.0.2` and
+  `remediation`.
+- **Happy path**: build `corvia` from source (`cd repos/corvia && cargo build`);
+  install; run the task; assert `:8020` responds; `curl -sS
+  http://127.0.0.1:8020/mcp` returns a valid MCP response.
+- **Doc grep**: `grep -rn "corvia workspace" CLAUDE.md AGENTS.md` returns
+  nothing after edits.
+- **E2E** (dev-loop Phase 8): fresh Claude Code session sees `corvia_search`
+  and `corvia_write` tools wired through `.mcp.json`.

--- a/docs/decisions/2026-04-17-mcp-access-http-default-design.md
+++ b/docs/decisions/2026-04-17-mcp-access-http-default-design.md
@@ -2,7 +2,15 @@
 
 **Date:** 2026-04-17
 **Status:** Approved
-**Scope:** `.devcontainer/.mcp.json`, `.devcontainer/Taskfile.yml`, `.devcontainer/scripts/post-start.sh`, `CLAUDE.md`, `AGENTS.md`
+**Scope:** `.devcontainer/.mcp.json`, `.devcontainer/Taskfile.yml`, `.devcontainer/scripts/post-start.sh`, `.devcontainer/scripts/lib.sh`, `AGENTS.md`, `README.md`
+
+> **Update (2026-04-17, post-review):** Corvia `v1.0.1` shipped during this work
+> — it already includes the `corvia serve` subcommand (PR #115) and a
+> `GET /healthz` endpoint (PR #116). Minimum required version is therefore
+> `v1.0.1`, not `v1.0.1`. The post-start probe uses `curl /healthz` instead
+> of a raw TCP open for functional readiness. The `post-start:` task order
+> places `corvia-serve` last so a hard-failure on a pre-v1.0.1 binary does
+> not skip `claude-integration` or `sweep`.
 
 ## Problem
 
@@ -29,7 +37,7 @@ subcommand exists in the corvia CLI — these are stale and misleading.
 
 **HTTP is the default and only supported MCP transport in this workspace.**
 Stdio is deprecated here. The workspace fix is the config + hardening half of
-the story; the release-side half (cutting v1.0.2 with the `serve` subcommand)
+the story; the release-side half (cutting v1.0.1 with the `serve` subcommand)
 is tracked separately by the maintainer.
 
 ## Design
@@ -39,7 +47,7 @@ is tracked separately by the maintainer.
 | File | Change |
 |------|--------|
 | `.devcontainer/.mcp.json` | Delete (untracked stdio workaround). |
-| `.devcontainer/Taskfile.yml` (`post-start:corvia-serve`) | Replace silent-skip capability guard with loud failure: print installed release tag, required minimum (`≥ v1.0.2`), actionable remediation, exit non-zero. Also promote the 5-second TCP-probe timeout from warning to hard failure. |
+| `.devcontainer/Taskfile.yml` (`post-start:corvia-serve`) | Replace silent-skip capability guard with loud failure: print installed release tag, required minimum (`≥ v1.0.1`), actionable remediation, exit non-zero. Also promote the 5-second TCP-probe timeout from warning to hard failure. |
 | `.devcontainer/scripts/post-start.sh` | Apply the same loud-failure contract to the bash-fallback equivalent, if present. |
 | `CLAUDE.md` | Remove/correct `corvia workspace ...` references. |
 | `AGENTS.md` | Same — the Quick Reference section lists nonexistent `corvia workspace` commands. |
@@ -61,7 +69,7 @@ Replacement:
 if ! corvia serve --help >/dev/null 2>&1; then
   tag="$(cat /usr/local/share/corvia-release-tag 2>/dev/null || echo unknown)"
   loge services "corvia serve: not supported by installed binary (tag=$tag)"
-  loge services "this workspace requires a serve-capable binary (corvia >= v1.0.2)"
+  loge services "this workspace requires a serve-capable binary (corvia >= v1.0.1)"
   loge services "remediation: task post-create:install-binary  (or rebuild devcontainer)"
   exit 1
 fi
@@ -78,7 +86,7 @@ silently masqueraded as success.
 
 - `.mcp.json` at the workspace root — already HTTP, already correct.
 - `.devcontainer/scripts/install_corvia.py` — "latest release" behavior is fine;
-  v1.0.2 will flow in once the maintainer cuts it.
+  v1.0.1 will flow in once the maintainer cuts it.
 - `corvia mcp` stdio subcommand in `repos/corvia/` — out of scope; stdio is
   deprecated at the workspace level, not removed from the binary.
 
@@ -86,7 +94,7 @@ silently masqueraded as success.
 
 - Dynamic `.mcp.json` rewriting at post-start.
 - Installer-side minimum-version pin (would create a merge-order hazard with
-  v1.0.2 tagging).
+  v1.0.1 tagging).
 - Removing `corvia mcp` from the CLI.
 
 ## Consequences
@@ -98,22 +106,22 @@ silently masqueraded as success.
 - Workspace docs stop advertising commands that don't exist.
 
 **Negative / accepted:**
-- Until v1.0.2 is released, a fresh devcontainer rebuild will fail at post-start
+- Until v1.0.1 is released, a fresh devcontainer rebuild will fail at post-start
   unless someone manually installs a serve-capable binary (e.g., `cargo build`
   + copy per the `CLAUDE.md` workaround). This is the intended tradeoff: loud
   failure over invisible breakage.
 
 **Ordering:**
-- This PR can merge before v1.0.2 is tagged. Users with an existing working
+- This PR can merge before v1.0.1 is tagged. Users with an existing working
   devcontainer are unaffected (post-start only fails on rebuild). New
-  containers built before v1.0.2 lands will see a clear error; the user cuts
-  v1.0.2 and a rebuild picks it up.
+  containers built before v1.0.1 lands will see a clear error; the user cuts
+  v1.0.1 and a rebuild picks it up.
 
 ## Testing
 
 - **Config parse**: `task --dry post-start:corvia-serve` parses cleanly.
-- **Missing-serve path**: place a pre-v1.0.2 binary at `/usr/local/bin/corvia`;
-  run the task; assert non-zero exit, stderr contains `v1.0.2` and
+- **Missing-serve path**: place a pre-v1.0.1 binary at `/usr/local/bin/corvia`;
+  run the task; assert non-zero exit, stderr contains `v1.0.1` and
   `remediation`.
 - **Happy path**: build `corvia` from source (`cd repos/corvia && cargo build`);
   install; run the task; assert `:8020` responds; `curl -sS

--- a/docs/decisions/2026-04-17-mcp-access-http-default-design.md
+++ b/docs/decisions/2026-04-17-mcp-access-http-default-design.md
@@ -7,7 +7,7 @@
 > **Update (2026-04-17, post-review):** Corvia `v1.0.1` shipped during this work
 > — it already includes the `corvia serve` subcommand (PR #115) and a
 > `GET /healthz` endpoint (PR #116). Minimum required version is therefore
-> `v1.0.1`, not `v1.0.1`. The post-start probe uses `curl /healthz` instead
+> `v1.0.1`, not `v1.0.2` as originally planned. The post-start probe uses `curl /healthz` instead
 > of a raw TCP open for functional readiness. The `post-start:` task order
 > places `corvia-serve` last so a hard-failure on a pre-v1.0.1 binary does
 > not skip `claude-integration` or `sweep`.

--- a/docs/plans/2026-04-17-mcp-access-http-default-plan.md
+++ b/docs/plans/2026-04-17-mcp-access-http-default-plan.md
@@ -229,7 +229,7 @@ New block (replace the whole block above with this):
         if ! corvia serve --help >/dev/null 2>&1; then
           tag="$(cat /usr/local/share/corvia-release-tag 2>/dev/null || echo unknown)"
           loge services "corvia serve: not supported by installed binary (tag=$tag)"
-          loge services "this workspace requires a serve-capable binary (corvia >= v1.0.2)"
+          loge services "this workspace requires a serve-capable binary (corvia >= v1.0.1)"
           loge services "remediation: task post-create:install-binary  (or rebuild devcontainer)"
           exit 1
         fi
@@ -272,7 +272,7 @@ cat /tmp/task.err
 
 Expected:
 - `exit=1`
-- stderr contains: `not supported by installed binary`, `requires a serve-capable binary (corvia >= v1.0.2)`, and `remediation:`.
+- stderr contains: `not supported by installed binary`, `requires a serve-capable binary (corvia >= v1.0.1)`, and `remediation:`.
 
 - [ ] **Step 5: Verify parse is clean**
 
@@ -352,7 +352,7 @@ step "Starting corvia serve"
 if ! corvia serve --help >/dev/null 2>&1; then
     _tag="$(cat /usr/local/share/corvia-release-tag 2>/dev/null || echo unknown)"
     fail_msg "corvia serve: not supported by installed binary (tag=$_tag)"
-    fail_msg "this workspace requires a serve-capable binary (corvia >= v1.0.2)"
+    fail_msg "this workspace requires a serve-capable binary (corvia >= v1.0.1)"
     fail_msg "remediation: python3 .devcontainer/scripts/install_corvia.py  (or rebuild devcontainer)"
     exit 1
 elif bash -c ': > /dev/tcp/127.0.0.1/8020' 2>/dev/null; then
@@ -412,7 +412,7 @@ WORKSPACE_ROOT=/tmp/fakews PATH="$TMPDIR:$PATH" bash -c '
   if ! corvia serve --help >/dev/null 2>&1; then
     _tag="$(cat /usr/local/share/corvia-release-tag 2>/dev/null || echo unknown)"
     fail_msg "corvia serve: not supported by installed binary (tag=$_tag)"
-    fail_msg "this workspace requires a serve-capable binary (corvia >= v1.0.2)"
+    fail_msg "this workspace requires a serve-capable binary (corvia >= v1.0.1)"
     fail_msg "remediation: python3 .devcontainer/scripts/install_corvia.py  (or rebuild devcontainer)"
     exit 1
   fi
@@ -423,7 +423,7 @@ cat /tmp/bash.err
 
 Expected:
 - `exit=1`
-- stderr contains: `not supported by installed binary`, `requires a serve-capable binary (corvia >= v1.0.2)`, and `remediation:`.
+- stderr contains: `not supported by installed binary`, `requires a serve-capable binary (corvia >= v1.0.1)`, and `remediation:`.
 
 - [ ] **Step 5: Commit**
 
@@ -562,10 +562,10 @@ esac
 EOF
 chmod +x "$TMPDIR/corvia"
 PATH="$TMPDIR:$PATH" task -t .devcontainer/Taskfile.yml post-start:corvia-serve 2>/tmp/final.err; echo "exit=$?"
-grep -E "v1.0.2|remediation" /tmp/final.err
+grep -E "v1.0.1|remediation" /tmp/final.err
 ```
 
-Expected: `exit=1` and the grep prints both the `v1.0.2` line and the `remediation:` line.
+Expected: `exit=1` and the grep prints both the `v1.0.1` line and the `remediation:` line.
 
 - [ ] **Step 5: Report branch state**
 
@@ -581,4 +581,4 @@ Expected: 4 new commits (Task 2, 3, 4, 5) plus the design-spec commit from brain
 ## Follow-ups (out of scope for this PR)
 
 - `README.md` contains the same stale `corvia workspace` references (lines 37, 38, 61, 67). Fix in a follow-up chore commit to keep this PR focused on the MCP access fix.
-- Cut corvia `v1.0.2` release so fresh devcontainer builds pick up a serve-capable binary (tracked by maintainer).
+- Cut corvia `v1.0.1` release so fresh devcontainer builds pick up a serve-capable binary (tracked by maintainer).

--- a/docs/plans/2026-04-17-mcp-access-http-default-plan.md
+++ b/docs/plans/2026-04-17-mcp-access-http-default-plan.md
@@ -1,0 +1,584 @@
+# MCP access: HTTP default / stdio deprecated — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist the workspace-side half of the MCP-access fix: keep `.mcp.json` on HTTP, delete the untracked stdio workaround, convert the silent-skip capability guard in `post-start:corvia-serve` to a loud failure (and promote the TCP-probe timeout to a hard failure), mirror the contract in the bash fallback, and strip stale `corvia workspace ...` references from `AGENTS.md`.
+
+**Architecture:** Edit-only change. No new files. Adds one helper (`loge`) to `lib.sh`. Behavior change is localized to two scripts (`Taskfile.yml`, `post-start.sh`) and one docs file (`AGENTS.md`). The untracked stdio workaround file is removed.
+
+**Tech Stack:** Bash, go-task (Taskfile.yml v3), markdown.
+
+**Reference spec:** `docs/decisions/2026-04-17-mcp-access-http-default-design.md`
+
+**Context already validated (no [POC] tasks needed):**
+- `lib.sh` has `log`/`logg`/`logm`/`logw` but no `loge`. Plan adds it (Task 2).
+- `.devcontainer/scripts/post-start.sh` exists and contains the same silent-skip pattern at lines 33–34 (fallback path).
+- `CLAUDE.md` has no `corvia workspace` references. Only `AGENTS.md` (lines 30, 32, 33, 35) does. Design's mention of CLAUDE.md is a false positive; plan updates AGENTS.md only. (`README.md` also has stale references but is out of scope per the approved design — noted as a follow-up.)
+- `corvia serve` reference in `CLAUDE.md` (Known Workarounds) is legitimate and stays.
+
+---
+
+### Task 1: Remove untracked stdio workaround
+
+**Files:**
+- Delete: `.devcontainer/.mcp.json` (untracked; contains stdio `corvia mcp` config)
+
+- [ ] **Step 1: Confirm the file is untracked and contains the expected stdio config**
+
+Run:
+```bash
+git status --porcelain .devcontainer/.mcp.json
+cat .devcontainer/.mcp.json
+```
+
+Expected:
+- `git status` prints a line beginning with `??` (untracked).
+- `cat` prints a JSON object with `"type": "stdio"`, `"command": "corvia"`, `"args": ["mcp"]`.
+
+- [ ] **Step 2: Delete the file**
+
+Run:
+```bash
+rm .devcontainer/.mcp.json
+```
+
+- [ ] **Step 3: Confirm removal**
+
+Run:
+```bash
+test ! -e .devcontainer/.mcp.json && echo OK
+git status --porcelain .devcontainer/.mcp.json
+```
+
+Expected: `OK`, then empty output from git-status.
+
+- [ ] **Step 4: No commit needed**
+
+The file was never tracked. Nothing to commit from this task. Proceed to Task 2.
+
+---
+
+### Task 2: Add `loge` helper to `lib.sh`
+
+**Files:**
+- Modify: `.devcontainer/scripts/lib.sh` (after the `logw` function, ~line 24)
+
+- [ ] **Step 1: Read the current log helpers**
+
+Run:
+```bash
+sed -n '5,25p' .devcontainer/scripts/lib.sh
+```
+
+Expected output (the existing helpers):
+```
+err() { echo "Error: $*" >&2; }
+
+# Colored [module] log output. Usage: log <module> <message>
+# Colors: infra=cyan, core=green, ide=magenta, warn=yellow
+log() {
+    local mod="$1"; shift
+    printf '\033[36m[%s]\033[0m %s\n' "$mod" "$*"
+}
+logg() {
+    local mod="$1"; shift
+    printf '\033[32m[%s]\033[0m %s\n' "$mod" "$*"
+}
+logm() {
+    local mod="$1"; shift
+    printf '\033[35m[%s]\033[0m %s\n' "$mod" "$*"
+}
+logw() {
+    local mod="$1"; shift
+    printf '\033[33m[%s]\033[0m %s\n' "$mod" "$*"
+}
+```
+
+- [ ] **Step 2: Add `loge` helper after `logw`**
+
+Use Edit tool to insert after the `logw` block. The new helper mirrors the existing style but uses red (`\033[31m`) and writes to stderr.
+
+```bash
+logw() {
+    local mod="$1"; shift
+    printf '\033[33m[%s]\033[0m %s\n' "$mod" "$*"
+}
+loge() {
+    local mod="$1"; shift
+    printf '\033[31m[%s]\033[0m %s\n' "$mod" "$*" >&2
+}
+```
+
+- [ ] **Step 3: Smoke-test the helper**
+
+Run:
+```bash
+bash -c 'source .devcontainer/scripts/lib.sh && loge services "test-error"' 2>/tmp/loge.err
+cat /tmp/loge.err
+```
+
+Expected: `/tmp/loge.err` contains `[services] test-error` (with ANSI escape prefix).
+
+- [ ] **Step 4: Shellcheck**
+
+Run:
+```bash
+command -v shellcheck >/dev/null && shellcheck .devcontainer/scripts/lib.sh || echo "shellcheck unavailable — skipping"
+```
+
+Expected: no warnings, or "shellcheck unavailable" (acceptable).
+
+- [ ] **Step 5: Commit**
+
+Run:
+```bash
+git add .devcontainer/scripts/lib.sh
+git commit -m "$(cat <<'EOF'
+chore(devcontainer): add loge helper for error-level red+stderr logs
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Replace Taskfile silent-skip with loud failure
+
+**Files:**
+- Modify: `.devcontainer/Taskfile.yml` (task `post-start:corvia-serve`, ~lines 58–85)
+
+**Behavior contract (new):**
+1. `corvia serve --help` must succeed → else print installed tag, required minimum, remediation; exit 1.
+2. If `:8020` already listening → log and exit 0 (unchanged).
+3. Start in background; probe up to 5 s → if TCP never opens, exit 1 (was: warn and exit 0).
+
+- [ ] **Step 1: Record current behavior for comparison**
+
+Run:
+```bash
+sed -n '58,86p' .devcontainer/Taskfile.yml
+```
+
+Note the current block — it has two silent skips: `exit 0` after the missing-`serve` warning, and an implicit `exit 0` after the "not responding after 5s" warning (loop falls through with no failure).
+
+- [ ] **Step 2: Verify current (broken) behavior with a stubbed corvia**
+
+Run:
+```bash
+TMPDIR=$(mktemp -d)
+cat > "$TMPDIR/corvia" <<'EOF'
+#!/bin/bash
+case "$1" in
+  serve) echo "error: unrecognized subcommand 'serve'" >&2; exit 2 ;;
+  *) exec /usr/local/bin/corvia "$@" ;;
+esac
+EOF
+chmod +x "$TMPDIR/corvia"
+PATH="$TMPDIR:$PATH" task -t .devcontainer/Taskfile.yml post-start:corvia-serve; echo "exit=$?"
+```
+
+Expected (current/broken): task prints the "not supported — skipping" warning and exits 0. This documents the bug.
+
+- [ ] **Step 3: Rewrite the task block**
+
+Use Edit to replace the existing `post-start:corvia-serve` block with the new one below. The `desc` stays the same; the `cmds:` body is fully replaced.
+
+Old block (in `.devcontainer/Taskfile.yml`, starting with `post-start:corvia-serve:`):
+
+```yaml
+  post-start:corvia-serve:
+    desc: "Start corvia serve (HTTP MCP server) in background"
+    cmds:
+      - |
+        source {{.SCRIPT_DIR}}/lib.sh
+        # 1. Capability guard — skip if binary doesn't support serve
+        if ! corvia serve --help >/dev/null 2>&1; then
+          logw services "corvia serve: not supported by installed binary — skipping"
+          exit 0
+        fi
+        # 2. Already-running check — skip if port 8020 is already listening
+        if bash -c ': > /dev/tcp/127.0.0.1/8020' 2>/dev/null; then
+          logg services "corvia serve: already running on port 8020"
+          exit 0
+        fi
+        # 3. Start server in background
+        logg services "corvia serve: starting on port 8020"
+        nohup corvia serve --port 8020 >> {{.WORKSPACE_ROOT}}/.corvia/serve.log 2>&1 &
+        # 4. Health probe — wait up to 5s for TCP connection
+        for i in 1 2 3 4 5; do
+          sleep 1
+          if bash -c ': > /dev/tcp/127.0.0.1/8020' 2>/dev/null; then
+            logg services "corvia serve: ready (${i}s)"
+            exit 0
+          fi
+        done
+        logw services "corvia serve: not responding after 5s — check .corvia/serve.log"
+```
+
+New block (replace the whole block above with this):
+
+```yaml
+  post-start:corvia-serve:
+    desc: "Start corvia serve (HTTP MCP server) in background"
+    cmds:
+      - |
+        source {{.SCRIPT_DIR}}/lib.sh
+        # 1. Capability guard — fail loudly if binary lacks `serve`.
+        # Workspace requires HTTP MCP; stdio is deprecated here.
+        if ! corvia serve --help >/dev/null 2>&1; then
+          tag="$(cat /usr/local/share/corvia-release-tag 2>/dev/null || echo unknown)"
+          loge services "corvia serve: not supported by installed binary (tag=$tag)"
+          loge services "this workspace requires a serve-capable binary (corvia >= v1.0.2)"
+          loge services "remediation: task post-create:install-binary  (or rebuild devcontainer)"
+          exit 1
+        fi
+        # 2. Already-running check — idempotent: exit 0 if :8020 already listening.
+        if bash -c ': > /dev/tcp/127.0.0.1/8020' 2>/dev/null; then
+          logg services "corvia serve: already running on port 8020"
+          exit 0
+        fi
+        # 3. Start server in background.
+        logg services "corvia serve: starting on port 8020"
+        nohup corvia serve --port 8020 >> {{.WORKSPACE_ROOT}}/.corvia/serve.log 2>&1 &
+        # 4. Health probe — 5s budget; hard-fail if TCP never opens.
+        for i in 1 2 3 4 5; do
+          sleep 1
+          if bash -c ': > /dev/tcp/127.0.0.1/8020' 2>/dev/null; then
+            logg services "corvia serve: ready (${i}s)"
+            exit 0
+          fi
+        done
+        loge services "corvia serve: not responding after 5s — check .corvia/serve.log"
+        exit 1
+```
+
+- [ ] **Step 4: Verify the new missing-`serve` path fails loudly**
+
+Run:
+```bash
+TMPDIR=$(mktemp -d)
+cat > "$TMPDIR/corvia" <<'EOF'
+#!/bin/bash
+case "$1" in
+  serve) echo "error: unrecognized subcommand 'serve'" >&2; exit 2 ;;
+  *) exec /usr/local/bin/corvia "$@" ;;
+esac
+EOF
+chmod +x "$TMPDIR/corvia"
+PATH="$TMPDIR:$PATH" task -t .devcontainer/Taskfile.yml post-start:corvia-serve 2>/tmp/task.err; echo "exit=$?"
+cat /tmp/task.err
+```
+
+Expected:
+- `exit=1`
+- stderr contains: `not supported by installed binary`, `requires a serve-capable binary (corvia >= v1.0.2)`, and `remediation:`.
+
+- [ ] **Step 5: Verify parse is clean**
+
+Run:
+```bash
+task -t .devcontainer/Taskfile.yml --list 2>&1 | grep -E "post-start:corvia-serve"
+```
+
+Expected: a line showing the task with its description. No YAML parse errors above it.
+
+- [ ] **Step 6: Commit**
+
+Run:
+```bash
+git add .devcontainer/Taskfile.yml
+git commit -m "$(cat <<'EOF'
+fix(devcontainer): make post-start:corvia-serve fail loudly
+
+Silent skip on missing 'corvia serve' subcommand hid the broken HTTP MCP
+path from users — Claude Code started without MCP tools and nothing
+visibly failed. Replace the skip with an actionable error (tag +
+required minimum + remediation) and promote the TCP-probe timeout to a
+hard failure so "serve started but died" also surfaces.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Apply same contract to bash fallback
+
+**Files:**
+- Modify: `.devcontainer/scripts/post-start.sh` (lines ~31–49, the "3/5 Starting corvia serve" block)
+
+- [ ] **Step 1: Re-read the current block for exact match**
+
+Run:
+```bash
+sed -n '31,49p' .devcontainer/scripts/post-start.sh
+```
+
+Expected: block starting with `# ── 3/5 ───` through the `[ "$_ready" -eq 0 ] && fail_msg ...` line.
+
+- [ ] **Step 2: Replace the block**
+
+Use Edit. The old block:
+
+```bash
+# ── 3/5 ───────────────────────────────────────────────────────────────
+step "Starting corvia serve"
+if ! corvia serve --help >/dev/null 2>&1; then
+    echo "    corvia serve: not supported by installed binary — skipping"
+elif bash -c ': > /dev/tcp/127.0.0.1/8020' 2>/dev/null; then
+    echo "    already running on port 8020"
+else
+    nohup corvia serve --port 8020 >> "$WORKSPACE_ROOT/.corvia/serve.log" 2>&1 &
+    _ready=0
+    for i in 1 2 3 4 5; do
+        sleep 1
+        if bash -c ': > /dev/tcp/127.0.0.1/8020' 2>/dev/null; then
+            echo "    ready (${i}s)"
+            _ready=1
+            break
+        fi
+    done
+    [ "$_ready" -eq 0 ] && fail_msg "not responding after 5s — check .corvia/serve.log"
+fi
+```
+
+New block:
+
+```bash
+# ── 3/5 ───────────────────────────────────────────────────────────────
+step "Starting corvia serve"
+if ! corvia serve --help >/dev/null 2>&1; then
+    _tag="$(cat /usr/local/share/corvia-release-tag 2>/dev/null || echo unknown)"
+    fail_msg "corvia serve: not supported by installed binary (tag=$_tag)"
+    fail_msg "this workspace requires a serve-capable binary (corvia >= v1.0.2)"
+    fail_msg "remediation: python3 .devcontainer/scripts/install_corvia.py  (or rebuild devcontainer)"
+    exit 1
+elif bash -c ': > /dev/tcp/127.0.0.1/8020' 2>/dev/null; then
+    echo "    already running on port 8020"
+else
+    nohup corvia serve --port 8020 >> "$WORKSPACE_ROOT/.corvia/serve.log" 2>&1 &
+    _ready=0
+    for i in 1 2 3 4 5; do
+        sleep 1
+        if bash -c ': > /dev/tcp/127.0.0.1/8020' 2>/dev/null; then
+            echo "    ready (${i}s)"
+            _ready=1
+            break
+        fi
+    done
+    if [ "$_ready" -eq 0 ]; then
+        fail_msg "corvia serve: not responding after 5s — check .corvia/serve.log"
+        exit 1
+    fi
+fi
+```
+
+Note: `fail_msg` already writes to stderr (defined at line 13); the bash fallback has no `loge` in scope. Remediation points at `install_corvia.py` directly because `task` is unavailable in this code path by definition.
+
+- [ ] **Step 3: Syntax check**
+
+Run:
+```bash
+bash -n .devcontainer/scripts/post-start.sh && echo OK
+command -v shellcheck >/dev/null && shellcheck .devcontainer/scripts/post-start.sh || echo "shellcheck unavailable — skipping"
+```
+
+Expected: `OK`, and no shellcheck warnings (or shellcheck unavailable).
+
+- [ ] **Step 4: Simulate missing-serve behavior (stub)**
+
+Run:
+```bash
+TMPDIR=$(mktemp -d)
+cat > "$TMPDIR/corvia" <<'EOF'
+#!/bin/bash
+case "$1" in
+  serve) echo "error: unrecognized subcommand 'serve'" >&2; exit 2 ;;
+  init)  echo "stub: ok"; exit 0 ;;
+  *) exec /usr/local/bin/corvia "$@" ;;
+esac
+EOF
+chmod +x "$TMPDIR/corvia"
+# Short-circuit: just execute the block of interest.
+set +e
+WORKSPACE_ROOT=/tmp/fakews PATH="$TMPDIR:$PATH" bash -c '
+  source .devcontainer/scripts/lib.sh
+  step() { printf " => %s\n" "$*"; }
+  fail_msg() { printf "    ... FAILED (%s)\n" "$*" >&2; }
+  set -euo pipefail
+  step "Starting corvia serve"
+  if ! corvia serve --help >/dev/null 2>&1; then
+    _tag="$(cat /usr/local/share/corvia-release-tag 2>/dev/null || echo unknown)"
+    fail_msg "corvia serve: not supported by installed binary (tag=$_tag)"
+    fail_msg "this workspace requires a serve-capable binary (corvia >= v1.0.2)"
+    fail_msg "remediation: python3 .devcontainer/scripts/install_corvia.py  (or rebuild devcontainer)"
+    exit 1
+  fi
+' 2>/tmp/bash.err
+echo "exit=$?"
+cat /tmp/bash.err
+```
+
+Expected:
+- `exit=1`
+- stderr contains: `not supported by installed binary`, `requires a serve-capable binary (corvia >= v1.0.2)`, and `remediation:`.
+
+- [ ] **Step 5: Commit**
+
+Run:
+```bash
+git add .devcontainer/scripts/post-start.sh
+git commit -m "$(cat <<'EOF'
+fix(devcontainer): mirror loud-failure contract in bash fallback
+
+Keep the legacy post-start.sh fallback aligned with the Taskfile: exit
+non-zero with actionable remediation if the installed corvia binary
+lacks 'serve', and promote TCP-probe timeout to hard failure.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Strip stale `corvia workspace` refs from AGENTS.md
+
+**Files:**
+- Modify: `AGENTS.md` (Quick Reference section; lines 28–36)
+
+**Mapping of stale → correct:**
+| Current (wrong) | Replacement |
+|---|---|
+| `corvia workspace status` | `corvia status` |
+| `corvia search "query"` | `corvia search "query"` (unchanged, already correct) |
+| `corvia workspace ingest` | `corvia ingest` |
+| `corvia workspace ingest --fresh` | `corvia ingest --fresh` |
+| `corvia serve &` | `corvia serve &` (unchanged, already correct) |
+| `corvia workspace init-hooks` | (remove — no corresponding subcommand; not needed for HTTP flow) |
+
+- [ ] **Step 1: Read the current block**
+
+Run:
+```bash
+sed -n '26,40p' AGENTS.md
+```
+
+Expected: a fenced `bash` code block with 5 lines beginning with `corvia ...`.
+
+- [ ] **Step 2: Replace stale lines**
+
+Use Edit to change each exact match:
+
+Replace `corvia workspace status          # Check workspace + service health` with `corvia status                   # Check indexed entries + recent traces`.
+
+Replace `corvia workspace ingest          # Index all repos` with `corvia ingest                   # Index the current workspace`.
+
+Replace `corvia workspace ingest --fresh  # Re-index from scratch` with `corvia ingest --fresh            # Re-index from scratch`.
+
+Delete the line `corvia workspace init-hooks      # Generate doc-placement hooks from config` entirely (including its trailing newline).
+
+- [ ] **Step 3: Verify no `corvia workspace` references remain in AGENTS.md**
+
+Run:
+```bash
+grep -n "corvia workspace" AGENTS.md || echo "clean"
+```
+
+Expected: `clean`.
+
+- [ ] **Step 4: Verify CLAUDE.md is still clean (sanity — no edit needed)**
+
+Run:
+```bash
+grep -n "corvia workspace" CLAUDE.md || echo "clean"
+```
+
+Expected: `clean`.
+
+- [ ] **Step 5: Commit**
+
+Run:
+```bash
+git add AGENTS.md
+git commit -m "$(cat <<'EOF'
+docs(agents): fix stale 'corvia workspace' subcommand references
+
+The corvia CLI has no 'workspace' subcommand — these references never
+worked. Replace with the actual subcommands (status, ingest) and drop
+the nonexistent 'init-hooks'.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Final verification
+
+No code changes; validation only. No commit.
+
+- [ ] **Step 1: Confirm no lingering stdio `.mcp.json` artifacts anywhere tracked**
+
+Run:
+```bash
+git ls-files | xargs grep -l '"type": "stdio"' 2>/dev/null || echo "clean"
+```
+
+Expected: `clean`.
+
+- [ ] **Step 2: Confirm root `.mcp.json` is still HTTP**
+
+Run:
+```bash
+cat .mcp.json
+```
+
+Expected: JSON with `"type": "http"` and `"url": "http://127.0.0.1:8020/mcp"`.
+
+- [ ] **Step 3: Confirm Taskfile parses**
+
+Run:
+```bash
+task -t .devcontainer/Taskfile.yml --list 2>&1 | head -20
+```
+
+Expected: list of tasks including `post-start:corvia-serve` with no YAML errors.
+
+- [ ] **Step 4: Re-run the missing-serve harness against the Taskfile (regression check)**
+
+Run:
+```bash
+TMPDIR=$(mktemp -d)
+cat > "$TMPDIR/corvia" <<'EOF'
+#!/bin/bash
+case "$1" in
+  serve) echo "error: unrecognized subcommand 'serve'" >&2; exit 2 ;;
+  *) exec /usr/local/bin/corvia "$@" ;;
+esac
+EOF
+chmod +x "$TMPDIR/corvia"
+PATH="$TMPDIR:$PATH" task -t .devcontainer/Taskfile.yml post-start:corvia-serve 2>/tmp/final.err; echo "exit=$?"
+grep -E "v1.0.2|remediation" /tmp/final.err
+```
+
+Expected: `exit=1` and the grep prints both the `v1.0.2` line and the `remediation:` line.
+
+- [ ] **Step 5: Report branch state**
+
+Run:
+```bash
+git log --oneline origin/master..HEAD
+```
+
+Expected: 4 new commits (Task 2, 3, 4, 5) plus the design-spec commit from brainstorming.
+
+---
+
+## Follow-ups (out of scope for this PR)
+
+- `README.md` contains the same stale `corvia workspace` references (lines 37, 38, 61, 67). Fix in a follow-up chore commit to keep this PR focused on the MCP access fix.
+- Cut corvia `v1.0.2` release so fresh devcontainer builds pick up a serve-capable binary (tracked by maintainer).


### PR DESCRIPTION
## Summary

Persisted fix for broken corvia MCP access in this workspace. The root cause was a silent-skip capability guard in the devcontainer `post-start:corvia-serve` task that swallowed the "missing `corvia serve` subcommand" case, leaving Claude Code sessions with zero corvia MCP tools and nothing visibly wrong. This PR converts the skip into a loud, actionable failure and fixes adjacent issues surfaced during review.

- **Loud failure contract**: `post-start:corvia-serve` (Taskfile + bash fallback) now exits 1 with tag / required-minimum / remediation on stderr when the installed binary lacks `serve`. TCP-probe timeout also promoted from warn-and-succeed to hard-fail.
- **HTTP default, stdio deprecated** at the workspace level. Removed the untracked `.devcontainer/.mcp.json` stdio workaround. Root `.mcp.json` stays HTTP (`http://127.0.0.1:8020/mcp`).
- **v1.0.1, not v1.0.2**: corvia v1.0.1 shipped during this work and already contains `corvia serve` (PR #115) and `GET /healthz` (PR #116). Required minimum is therefore v1.0.1.
- **`/healthz` probe** (instead of raw TCP open) — functional readiness, not just port-bound. Probe budget widened to 30s to accommodate first-boot embedder download (~17s observed for nomic-embed-text-v1.5).
- **Task ordering**: `post-start:corvia-serve` moved to the end of the aggregate `post-start:` chain so a hard-failure on a pre-v1.0.1 binary does not cascade into skipping superpowers install + cache sweep. Bash fallback mirrors the reorder.
- **Log rotation**: `serve.log` → `serve.log.prev` on each start; new log is truncated. Prevents unbounded growth on long-lived workspace volumes.
- **Docs**: stripped stale `corvia workspace ...` subcommand references (never existed in the CLI) from `AGENTS.md` and `README.md`. Added `loge` red/stderr helper to `lib.sh`.

## Review process

Followed the `/dev-loop` skill end-to-end:
- Design: `docs/decisions/2026-04-17-mcp-access-http-default-design.md`
- Plan: `docs/plans/2026-04-17-mcp-access-http-default-plan.md`
- Phase 6: 5-persona review (Senior SWE, PM, QA, SRE/Platform, Container/Deploy) — 1 Critical + 4 Important blockers all addressed in commits `287d2613` and `751f27fe`.
- Phase 8: E2E on the actual env — happy path (installer upgrade → serve boot → MCP tools live), broken path (stubbed pre-v1.0.1 binary → loud fail + superpowers still installs), idempotent re-run, log rotation, empty tag-file fallback. 1 blocker surfaced (5s probe too short for cold-start) → fixed in `75298c74`.

## Follow-ups (tracked, not in this PR)

- PID file / lifecycle management for `nohup corvia serve` (SRE I2). Today the documented stop path is `pkill -9 -f "corvia serve"` per `CLAUDE.md`.

## Test Plan

- [ ] Verify `curl -sf http://127.0.0.1:8020/healthz` returns 200 in a fresh devcontainer built with v1.0.1+.
- [ ] Stub a pre-v1.0.1 `corvia` on PATH; confirm `task post-start:corvia-serve` exits 1 with the expected 3-line error on stderr.
- [ ] Run full `task post-start` with the stub; confirm superpowers install completes before the serve step fails.
- [ ] Verify `.corvia/serve.log.prev` captures the previous boot after a serve restart.
- [ ] `grep -rn "corvia workspace" CLAUDE.md AGENTS.md README.md` returns empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)