### PR TITLE
chore: ignore stray .corvia/ in .devcontainer/ and tools/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,13 @@ repos/corvia/
 # corvia data directory — derived data excluded via .corvia/.gitignore
 # entries/ and corvia.toml inside .corvia/ are trackable for team sharing.
 
+# Stray .corvia/ stores created in subdirectories (defense-in-depth; the
+# trace-file path bug that spawned these was fixed in corvia CLI — see
+# crates/corvia-cli/src/main.rs:resolve_trace_path. These patterns keep any
+# future regression out of git until the root cause is caught again).
+.devcontainer/.corvia/
+tools/**/.corvia/
+
 # Local working files (per-user, not shared)
 .local/
 .devcontainer/.corvia-workspace-flags


### PR DESCRIPTION
## Summary

Workspace side of the `.corvia/` consolidation. Pair PR: [chunzhe10/corvia#131](https://github.com/chunzhe10/corvia/pull/131) (code fix in the corvia CLI — that's the real remediation).

- **Migration receipt**: 7 unique entries from `.devcontainer/.corvia/entries/` were copied into `/workspaces/corvia-workspace/.corvia/entries/` (63 → 70 entries total, zero ID collisions since entry IDs are ULIDs).
- **Cleanup**: three stray dirs removed out-of-band (all were untracked):
  - `.devcontainer/.corvia/` (671 MB including models + 7 entries — migrated first)
  - `repos/corvia/.corvia/` (1.6 MB — trace file only)
  - `tools/carousel-render/.corvia/` (4 KB — empty trace file)
- **Code change in this PR**: just `.gitignore` — defense-in-depth patterns so a future regression of the cwd-relative-path class can't land in git. `repos/corvia/.corvia/` is already covered by the existing `repos/corvia/` umbrella ignore.

## Invariant established
```
$ find . -type d -name .corvia -not -path '*/target/*' -not -path '*/node_modules/*'
./.corvia
```

## Test plan
- [x] Rebuilt the fixed `corvia` binary, invoked `corvia status` from `repos/corvia/`, `.devcontainer/`, and `/tmp/empty-dir/` — none created a new `.corvia/`.
- [x] Invariant check after all cleanup: only workspace-root `.corvia/` remains.
- [ ] After corvia/#131 merges: rebuild binary and confirm server restart no longer produces a stray trace file at `repos/corvia/.corvia/traces.jsonl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)